### PR TITLE
Fix package format for pip

### DIFF
--- a/crispy_forms_semantic_ui/README
+++ b/crispy_forms_semantic_ui/README
@@ -1,11 +1,13 @@
-### crispy-forms-semantic-ui
+crispy-forms-semantic-ui
+========================
 
 crispy-forms-semantic-ui contains a set of templates that can be used to get 
 semantic UI form layouts and error handling in [`django-crispy-forms`](https://github.com/maraujop/django-crispy-forms). 
 
 Tested with Semantic-UI 2.2.4.
 
-### Install
+Install
+=======
 
 1. `pip install crispy-forms-semantic-ui`
 

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,13 @@ from setuptools import setup, find_packages
 
 from crispy_forms_semantic_ui import __version__
 
-with open(os.path.join(os.path.dirname(__file__), 'README_PIP.md')) as readme:
+APPNAME = 'crispy-forms-semantic-ui'
+
+with open(os.path.join(os.path.dirname(__file__), APPNAME.replace('-','_'), 'README')) as readme:
     README = readme.read()
 
 setup(
-    name='crispy-forms-semantic-ui',
+    name=APPNAME,
     version='.'.join(map(str, __version__)),
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Having the README_PIP.md and other files in the top level of the package
meant that they aren't included when `python setup.py bdist_egg` is
run.

(This is so that they don't end up in the top-level of the
./site-packages/ folder when the package is installed.)

This commit:
1. Moves README_PIP.md to the crispy_forms_semantic_ui/ folder (and
   renames it README).
   
   Also took the liberty of re-writing the README_PIP.md file as rst :)
2. Modifies setup.py to locate the README file for the long description
   in its new location
   
   (This is a bit hacky due to the fact that the app name uses "-" whilst
   the folder name uses "_". You might want to change this? :) )

When built using bdist and bdist_egg all required files are included, so
the package should now be able to be downloaded and installed using pip.

Signed-off-by: Rod Manning rod.t.manning@gmail.com
