### PR TITLE
Generic install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,23 @@ Any help to complete it is appeciated.
 1. `pip install crispy-forms-semantic-ui`
 
 2. set `semantic-ui` as your `CRISPY_TEMPLATE_PACK` in your projects' `settings.py`
+
+### Generic install steps
+
+3. add `crispy_forms_semantic_ui` to your `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    ...
+    'crispy_forms',
+    'crispy_forms_semantic_ui',
+    ...
+]
+```
+
+4. Add `semantic-ui` to the allowed `CRISPY_ALLOWED_TEMPLATE_PACKS` array in your `settings`:
+
+```python
+CRISPY_ALLOWED_TEMPLATE_PACKS = ('bootstrap', 'uni_form', 'bootstrap3',
+                                 'bootstrap4', 'semantic-ui',)
+```

--- a/crispy_forms_semantic_ui/templates/semantic-ui/display_form.html
+++ b/crispy_forms_semantic_ui/templates/semantic-ui/display_form.html
@@ -1,5 +1,7 @@
 {% if form.form_html %}
-    {{ form.media }}
+    {% if include_media %}
+        {{ form.media }}
+    {%  endif %}
     {% if form_show_errors %}
         {% include "semantic-ui/errors.html" %}
     {% endif %}


### PR DESCRIPTION
Hi,

I had to do the things listed under Generic install steps to make this work in a standard django project.
All info here is taken from the issues referencing `CRISPY_ALLOWED_TEMPLATE_PACKS` and `CRISPY_TEMPLATE_PACK`.